### PR TITLE
fix byte/str typeerror in decode_0ce7

### DIFF
--- a/tncc.py
+++ b/tncc.py
@@ -88,7 +88,7 @@ def decode_0ce7(buf, indent):
     logging.debug('%scmd 0ce7 (id %08x string) %d bytes', indent, id, len(buf))
 
     if s.startswith(b'COMPRESSED:'):
-        typ, length, data = s.split(':', 2)
+        typ, length, data = s.split(b':', 2)
         s = zlib.decompress(data)
 
     s = s.rstrip(b'\0')


### PR DESCRIPTION
~~~
Traceback (most recent call last):
  File "tncc.py", line 606, in <module>
    server.process_cmd()
  File "tncc.py", line 547, in process_cmd
    cookie = self.tncc.get_cookie(args['Cookie'], args['DSSIGNIN'])
  File "tncc.py", line 462, in get_cookie
    _1, _2, msg_decoded = decode_packet(msg_raw)
  File "tncc.py", line 131, in decode_packet
    data = decode_0013(data, indent)
  File "tncc.py", line 45, in decode_0013
    length, cmd, out = decode_packet(buf, indent + "  ")
  File "tncc.py", line 137, in decode_packet
    data = decode_0ce4(data, indent)
  File "tncc.py", line 72, in decode_0ce4
    length, cmd, out = decode_packet(buf, indent + "  ")
  File "tncc.py", line 141, in decode_packet
    data = decode_0ce7(data, indent)
  File "tncc.py", line 91, in decode_0ce7
    typ, length, data = s.split(':', 2)
TypeError: a bytes-like object is required, not 'str'